### PR TITLE
プロフィールCRUD修正、認証管理の修正

### DIFF
--- a/back/app/api/endpoints/profile.py
+++ b/back/app/api/endpoints/profile.py
@@ -80,19 +80,16 @@ async def create_profile_endpoint(
             raise HTTPException(
                 status_code=400, detail="生年月日の形式が正しくありません"
             )
-            
+
         try:
-            # UUIDとして解析を試みる
-            user_id = UUID(user_id)
-        except ValueError:
-            # UUIDでない場合、Firebase UIDとしてユーザーを検索
+            # Firebase UIDとしてユーザーを検索
             user_result = await db.execute(
                 select(Users).where(Users.firebase_uid == user_id)
             )
             user = user_result.scalar_one_or_none()
-            if not user:
-                raise HTTPException(status_code=404, detail="ユーザーが見つかりません")
             user_id = user.id
+        except ValueError as e:
+            raise HTTPException(status_code=404, detail=f"{e}ユーザーが見つかりません")
 
         # 画像がアップロードされた場合は保存
         image_path = None  # プロフィール作成なので、画像は保存されていない状態
@@ -141,16 +138,15 @@ async def get_profile_endpoint(user_id: str, db: AsyncSession = Depends(get_asyn
         logger.info("プロフィール取得リクエスト受信成功")
         # プロフィール取得
         try:
-            uuid_user_id = UUID(user_id)
-            # UUIDの場合、UUIDで検索
-            profile = await profile_crud.get_profile_by_user_id(db, uuid_user_id)
-        except ValueError:
-            # UUIDでない場合、Firebase UIDとして検索
+            # Firebase UIDとして検索
             profile = await profile_crud.get_profile_by_firebase_uid(db, user_id)
+        except ValueError as e:
+            raise HTTPException(
+                status_code=404, detail=f"{e}プロフィールが存在しません"
+            )
 
         if profile is None:
             logger.info(f"ユーザー{user_id}のプロフィールが存在しません")
-            raise HTTPException(status_code=404, detail="プロフィールが存在しません")
 
         logger.info("プロフィール取得成功")
         response_profile = ResponseProfile.model_validate(profile)

--- a/front/src/api/client/profile/profileApi.tsx
+++ b/front/src/api/client/profile/profileApi.tsx
@@ -4,14 +4,14 @@ import axios from 'axios'
 const BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080'
 
 export const profileApi = {
-  create: async (data: CreateProfileRequest, userId: string) => {
+  create: async (data: CreateProfileRequest, firebase_uid: string) => {
     try {
       // 日付の変換
       const formattedBirthday =
         data.birthday instanceof Date ? data.birthday.toISOString().split('T')[0] : data.birthday
 
       const formData = new FormData()
-      formData.append('user_id', userId)
+      formData.append('firebase_uid', firebase_uid)
       formData.append('name', data.name)
       formData.append('team_name', data.team_name)
       formData.append('birthday', formattedBirthday)
@@ -27,7 +27,7 @@ export const profileApi = {
       if (data.image instanceof File) {
         formData.append('image', data.image)
       }
-      
+
       const response = await axios.post(`${BASE_URL}/profile/`, formData, {
         timeout: 10000, // 10秒のタイムアウト
         headers: {
@@ -60,9 +60,9 @@ export const profileApi = {
       }
     }
   },
-  get: async (userId: string) => {
+  get: async (firebase_uid: string) => {
     try {
-      const response = await axios.get(`${BASE_URL}/profile/${userId}`)
+      const response = await axios.get(`${BASE_URL}/profile/${firebase_uid}`)
       return response.data
     } catch (error: any) {
       if (error.response && error.response.status === 404) {

--- a/front/src/app/Player/CreateProfile/page.tsx
+++ b/front/src/app/Player/CreateProfile/page.tsx
@@ -25,8 +25,7 @@ const CreateProfile = () => {
   const [imagePreview, setImagePreview] = useState<string | null>(null)
   const [isCompleted, setIsCompleted] = useState<true | null>(null)
   const [formData, setFormData] = useState<CreateProfileRequest>({
-    //現在、ログイン機能を作成していないので現在はこちらのダミーデータを使用して進めております
-    user_id: user?.uid || '', // Firebaseのユーザーuid
+    firebase_uid: user?.uid || '', // Firebaseのユーザーuid
     name: '',
     birthday: new Date(),
     team_name: '',
@@ -85,15 +84,15 @@ const CreateProfile = () => {
       return
     }
 
-    if (!formData.user_id) {
+    if (!formData.firebase_uid) {
       setError('ログインが必要です。再度ログインしてください。')
       setAlert({ status: 'error', message: 'ログインが必要です', isVisible: true })
       return
     }
 
     // ここでUUID形式として有効になっているかについての検証
-    if (!formData.user_id || !/^[A-Za-z0-9]{28}$/.test(formData.user_id)) {
-      console.error('無効なFirebase UID形式:', formData.user_id)
+    if (!formData.firebase_uid || !/^[A-Za-z0-9]{28}$/.test(formData.firebase_uid)) {
+      console.error('無効なFirebase UID形式:', formData.firebase_uid)
       setError('ユーザーIDの形式が正しくありません。再度ログインしてください。')
       return
     }
@@ -106,7 +105,7 @@ const CreateProfile = () => {
     }
     // リクエストする型定義に問題がなければリクエストを開始
     try {
-      await profileApi.create(dataToSubmit, dataToSubmit.user_id)
+      await profileApi.create(dataToSubmit, dataToSubmit.firebase_uid)
       setAlert({
         status: 'success',
         message: 'プロフィール作成に成功しました。',

--- a/front/src/app/Player/EditProfile/page.tsx
+++ b/front/src/app/Player/EditProfile/page.tsx
@@ -46,7 +46,7 @@ const EditProfile = () => {
     isVisible: false,
   })
 
-  const userId = user?.uid || ''
+  const firebase_uid = user?.uid || ''
 
   // 未認証時のリダイレクト処理
   useEffect(() => {
@@ -58,12 +58,12 @@ const EditProfile = () => {
 
   useEffect(() => {
     // ユーザーIDが取得できるまで待機
-    if (!userId) return
+    if (!firebase_uid) return
 
     const fetchProfile = async () => {
       try {
         setLoading(true)
-        const data = await profileApi.get(userId)
+        const data = await profileApi.get(firebase_uid)
         setProfile(data)
         setName(data.name)
         setTeamName(data.team_name)
@@ -88,7 +88,7 @@ const EditProfile = () => {
       }
     }
     fetchProfile()
-  }, [userId])
+  }, [firebase_uid])
   const handleImageClick = () => {
     if (fileInputRef.current) {
       fileInputRef.current.click()
@@ -131,7 +131,7 @@ const EditProfile = () => {
       introduction: introduction || '',
       image,
       // validateProfileの型に合わせるためにuser_idを追加
-      user_id: userId,
+      firebase_uid: firebase_uid,
     }
     const validationErrors = validateProfile(formData)
     if (image) {

--- a/front/src/app/layout.tsx
+++ b/front/src/app/layout.tsx
@@ -3,7 +3,6 @@ import { Inter } from 'next/font/google'
 import { Providers } from '../app/providers'
 import '../styles/globals.css'
 import { auth } from '../auth'
-import { AuthProvider } from '..//contexts/AuthContext'
 
 const inter = Inter({ subsets: ['latin'] })
 
@@ -21,9 +20,7 @@ export default async function RootLayout({
   return (
     <html lang="ja" suppressHydrationWarning>
       <body className={inter.className}>
-        <Providers session={session}>
-          <AuthProvider>{children}</AuthProvider>
-        </Providers>
+        <Providers session={session}>{children}</Providers>
       </body>
     </html>
   )

--- a/front/src/types/profile.tsx
+++ b/front/src/types/profile.tsx
@@ -23,7 +23,7 @@ export enum DominantHand {
 }
 
 export type CreateProfileRequest = {
-  user_id: string
+  firebase_uid: string
   name: string
   team_name: string
   birthday: Date | string


### PR DESCRIPTION
ここまでの手順

1. endpointsディレクトリのprofile.pyの修正。
2. layout.tsxの修正。

## 修正前の課題：
* フロントエンドからfirebase_uidがstringで渡されているにも関わらず、バックエンドではUUIDとして受け取るコードを書いていた。そのため、再度自分でコードを確認した際に、１からコードを読まないと何をしているか理解することができなかった
*  layout.tsxでは、AuthProviderをインポートして各ページの認証状態を管理していたが、providers.tsxでもAuthProviderをインポートしていたため、各ページに対して二重で認証管理している状態になっていました。

## 修正した箇所：
* endpointsのprofile.pyで、フロントエンドからfirebase_uidをstringとして受け取れるように修正しました。
* layout.tsxで記述していたAuthProviderのインポートを削除しました。

## 修正後：
* コードがスムーズになりました。
* 処理の流れが理解しやすくなりました。
* 正常にプロフィール作成、編集が起動しています。
*  layout.tsxのAuthProviderを削除後も、各ページで問題なく認証管理ができています。




## 動作確認
* 問題なくコンテナが動作し、fastapiとnextjsの画面が表示される。
* 問題なくアカウント作成からログイン、プロフィール作成、トレーニング追加機能が正常に動作している。

## その他
layout.tsxに修正を加えた理由について、コードを確認している際に、providers.tsxとlayout.tsxで認証状態を管理している状態になっており、無駄なコードだと思いました。何かご指摘があった場合は、ご連絡いただければ幸いです。
