### PR TITLE
FirebaseStorageを使用して画像の保存する場所を変更致しました。

### DIFF
--- a/back/.gitignore
+++ b/back/.gitignore
@@ -5,7 +5,7 @@ __pycache__/
 
 # 画像をgithubにあげないように記述しました。
 uploads/profile_images/
-
+.firebase-service-account-key.json
 # C extensions
 *.so
 

--- a/back/app/api/endpoints/profile.py
+++ b/back/app/api/endpoints/profile.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException, Form, UploadFile, File, status
+from fastapi import APIRouter, Depends, HTTPException, Form, UploadFile, File
 from typing import Optional
 from sqlalchemy.ext.asyncio import AsyncSession
 from uuid import UUID
@@ -91,14 +91,11 @@ async def create_profile_endpoint(
         except ValueError as e:
             raise HTTPException(status_code=404, detail=f"{e}ユーザーが見つかりません")
 
-        # 画像がアップロードされた場合は保存
         image_path = None  # プロフィール作成なので、画像は保存されていない状態
-        # imageオブジェクト自体が存在し、値が None ではない）image オブジェクトに filename 属性が存在している場合
+        # Firebaseに保存してから、URLを作成するためのパスのみを取得している
+        # image_pathにしているのはデータベースに保存するため
         if image and image.filename:
-            await validate_image(image)
-            image_path = await save_profile_image(
-                image
-            )  # image_pathにしているのはデータベースに保存するため
+            image_path = await save_profile_image(image)
 
         # CreateProfileモデルを作成
         try:

--- a/back/app/core/config.py
+++ b/back/app/core/config.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+
 # coreディレクトリは、アプリケーションの中核となる設定や機能を格納する場所です
 # アプリケーション全体の設定
 # データベース設定
@@ -37,6 +38,9 @@ class Settings(BaseSettings):
     PROFILE_IMAGE_DIR: str = "profile_images"
     MAX_IMAGE_SIZE: int = 5 * 1024 * 1024  # 5MB
 
+    # Firebase設定
+    FIREBASE_STORAGE_BUCKET: str = "web-baseball.firebasestorage.app"
+    FIREBASE_SERVICE_ACCOUNT_KEY_PATH: str = ".firebase-service-account-key.json"
 
     def get_database_url(self, is_async: bool = False) -> str:
         if is_async:

--- a/back/app/core/firebase.py
+++ b/back/app/core/firebase.py
@@ -1,0 +1,23 @@
+import firebase_admin
+from firebase_admin import credentials
+from app.core.config import settings
+import os
+
+
+def initialize_firebase():
+    """Firebase Adminの初期化"""
+    if not firebase_admin._apps:
+        # サービスアカウントキーのパス
+        key_path = os.path.join(
+            settings.ROOT_DIR_PATH,
+            settings.FIREBASE_SERVICE_ACCOUNT_KEY_PATH,
+        )
+        # 認証情報の設定 : Firebase Adminを使用するための認証情報を作成
+        cred = credentials.Certificate(key_path)
+
+        # Firebase初期化
+        firebase_admin.initialize_app(
+            cred, {"storageBucket": settings.FIREBASE_STORAGE_BUCKET}
+        )
+
+    return firebase_admin

--- a/back/app/utils/image.py
+++ b/back/app/utils/image.py
@@ -1,11 +1,10 @@
 import os
-import shutil
 import uuid
 from fastapi import UploadFile, HTTPException
-from pathlib import Path
-import aiofiles
 from app.core.config import settings
 from app.core.logger import get_logger
+from app.core.firebase import initialize_firebase
+from firebase_admin import storage
 
 logger = get_logger(__name__)
 
@@ -21,8 +20,11 @@ ALLOWED_EXTENSIONS = {".jpg", ".jpeg", ".png", ".gif"}
 # 最大ファイルサイズは設定から取得
 MAX_FILE_SIZE = settings.MAX_IMAGE_SIZE
 
-async def validate_image(image: UploadFile) -> None:
+# Firebase初期化
+initialize_firebase()
 
+
+async def validate_image(image: UploadFile) -> None:
     if not image or not image.filename:
         return
 
@@ -30,7 +32,7 @@ async def validate_image(image: UploadFile) -> None:
     if file_ext not in ALLOWED_EXTENSIONS:
         raise HTTPException(
             status_code=400,
-            detail=f"画像形式が不正です。許容されている形式: {', '.join(ALLOWED_EXTENSIONS)}"
+            detail=f"画像形式が不正です。許容されている形式: {', '.join(ALLOWED_EXTENSIONS)}",
         )
 
     # ファイルサイズチェック
@@ -39,56 +41,113 @@ async def validate_image(image: UploadFile) -> None:
 
     if len(contents) > MAX_FILE_SIZE:
         raise HTTPException(
-            status_code=400, 
-            detail=f"ファイルサイズが大きすぎます。最大サイズ: {MAX_FILE_SIZE/1024/1024:.1f}MB"
+            status_code=400,
+            detail=f"ファイルサイズが大きすぎます。最大サイズ: {MAX_FILE_SIZE / 1024 / 1024:.1f}MB",
         )
 
 
-
 async def save_profile_image(image: UploadFile) -> str:
-    #プロフィールを保存し、保存されたpathを返す
+    # プロフィールを保存し、保存されたpathを返す
 
     if not image or not image.filename:
         return None
 
     await validate_image(image)
 
-    # ファイル名をユニークにするためにUUIDを使用
-    file_ext = os.path.splitext(image.filename.lower())[1]
-    unique_filename = f"{uuid.uuid4()}{file_ext}"
-
-    # 保存先のパス
-    file_path = os.path.join(PROFILE_IMAGES_DIR, unique_filename)
-
     try:
-        # 画像を保存　withステートメントにより、処理が終わったら自動的にファイルが閉じられる
-        async with aiofiles.open(file_path, "wb") as out_file:
-            contents = await image.read()
-            await out_file.write(contents)
+        # ファイル名をユニークにするためにUUIDを使用
+        # 拡張子のみを取得
+        file_ext = os.path.splitext(image.filename.lower())[1]
+        unique_filename = f"{uuid.uuid4()}{file_ext}"
 
-        # データベースに保存するための相対パスを返す
-        relative_path = f"/{settings.UPLOAD_DIR}/{settings.PROFILE_IMAGE_DIR}/{unique_filename}"
-        logger.info(f"画像保存成功: {relative_path}")
-        return relative_path
+        # Firebase内のパス
+        storage_path = f"profile_images/{unique_filename}"
+
+        # ファイル内容を読み込む
+        contents = await image.read()
+
+        # バケット取得（保存場所）
+        bucket = storage.bucket()
+
+        # blobオブジェクト作成
+        # これにより作成、取得、削除を行うことが可能になる
+        blob = bucket.blob(storage_path)
+
+        # メモリからアップロード
+        # web標準に従った適切な画像ファイルのみをアップロード、テキストなどを保存しないため
+        blob.upload_from_string(
+            contents,
+            content_type=f"image/{file_ext[1:]}"
+            if file_ext != ".jpg"
+            else "image/jpeg",
+        )
+
+        logger.info(f"Firebase Storageに画像保存成功: {storage_path}")
+        # 詳細画面で表示する際にURLが必要で、その際にこのパス名をデータベースに保存して、フロントエンドに渡す際に、
+        # このパス名を指定することで、Firebaseから画像のURL取得
+        return storage_path
+
     except Exception as e:
         logger.error(f"画像保存エラー:{str(e)}")
-        raise HTTPException(status_code=500, detail=f"画像の保存に失敗しました: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"画像の保存に失敗しました: {str(e)}"
+        )
+
 
 async def delete_profile_image(image_path: str) -> bool:
+    """Firebase Storageから画像を削除"""
     try:
-        if not image_path: #削除するものがない
+        if not image_path:  # 削除するものがない
             return False
-        # 相対パスから実際のファイルパスを取得
-        filename = os.path.basename(image_path)
-        file_path = os.path.join(PROFILE_IMAGES_DIR, filename)
+        # バケット取得
+        bucket = storage.bucket()
 
-        if os.path.exists(file_path): #相対パスがある場合、削除してTrueを返す
-            os.remove(file_path)
-            logger.info(f"画像削除成功: {file_path}")
+        # blob取得
+        blob = bucket.blob(image_path)
+
+        # 存在確認して削除
+        if blob.exists():
+            blob.delete()
+            logger.info(f"画像削除成功: {image_path}")
             return True
-        else:     #相対パスがない場合、削除できないので、Falseを返す
-            logger.warning(f"削除しようとしたが画像が見つかりません: {file_path}")
+        else:
+            logger.warning(f"画像が見つかりません: {image_path}")
             return False
     except Exception as e:
         logger.error(f"画像削除エラー：{str(e)}")
         return False
+
+
+def get_image_url(image_path: str) -> str:
+    """Firebase Storageの画像URLを取得"""
+
+    if not image_path:
+        logger.info("image_path is None, returning None")
+        return None
+
+    try:
+        # バケット取得
+        bucket = storage.bucket()
+
+        # blob取得
+        blob = bucket.blob(image_path)
+
+        # blobが存在するか確認
+        exists = blob.exists()
+
+        if not exists:
+            logger.warning(f"画像が見つかりません: {image_path}")
+            return None
+
+        # 署名付きURL生成（1時間有効）
+        url = blob.generate_signed_url(
+            version="v4",
+            expiration=3600,  # 1時間
+            method="GET",
+        )
+
+        logger.info(f"画像URL生成成功: {url[:50]}...")  # URLの一部のみログに出力
+        return url
+    except Exception as e:
+        logger.error(f"URL生成エラー: {str(e)}", exc_info=True)
+        return None

--- a/back/compose.yml
+++ b/back/compose.yml
@@ -51,6 +51,7 @@ services:
     environment:
       SQLALCHEMY_WARN_20: 1
       DATABASE_URL: "postgresql://docker:docker@db:5432/baseball_note"
+      FIREBASE_STORAGE_BUCKET: "web-baseball.firebasestorage.app"
     healthcheck:
       test: "curl -f http://localhost:80/docs || exit 1"
       interval: 5s
@@ -74,6 +75,7 @@ services:
       - .:/backend
       - /backend/.venv
       - ./uploads:/backend/uploads  # アップロードディレクトリのマウントを追加
+      - ./.firebase-service-account-key:/backend/app/.firebase-service-account-key.json
     links:
       - db
     restart: always

--- a/back/requirements.txt
+++ b/back/requirements.txt
@@ -11,6 +11,7 @@ email-validator==2.0.0.post2
 fastapi==0.100.0
 fastapi-debug-toolbar==0.5.0
 fire==0.5.0
+firebase-admin==6.2.0
 h11==0.14.0
 httpcore==0.17.2
 httpx==0.24.1

--- a/front/next.config.mjs
+++ b/front/next.config.mjs
@@ -7,8 +7,10 @@ const nextConfig = {
   experimental: {
     optimizePackageImports: ["@chakra-ui/react"],
   },
+  // Next.jsはデフォルトでは外部ドメインからの画像取得を制限しているので、
+  // Firebase Storage（Google Cloud Storage）からの画像取得を許可するために記述
   images: {
-    domains: ['localhost'], // localhost:8080からの画像読み込みを許可
+    domains: ['localhost',  'storage.googleapis.com'],
   },
 }
 

--- a/front/src/app/Player/CreateProfile/page.tsx
+++ b/front/src/app/Player/CreateProfile/page.tsx
@@ -200,7 +200,7 @@ const CreateProfile = () => {
                               alt="プロフィール画像"
                               width={128}
                               height={128}
-                              className="w-full h-full object-cover"
+                              className="w-full h-full object-cover rounded-full"
                             />
                           ) : (
                             <svg

--- a/front/src/app/Player/EditProfile/page.tsx
+++ b/front/src/app/Player/EditProfile/page.tsx
@@ -76,8 +76,8 @@ const EditProfile = () => {
         setPlayerPosition(data.player_position)
         setAdmiredPlayer(data.admired_player)
         setIntroduction(data.introduction)
-        if (data.image_path) {
-          setImagePreview(`${process.env.NEXT_PUBLIC_API_URL}${data.image_path}`)
+        if (data.image_url) {
+          setImagePreview(data.image_url)
         }
         setError(null)
       } catch (error: any) {

--- a/front/src/app/Player/ProfileDetail/page.tsx
+++ b/front/src/app/Player/ProfileDetail/page.tsx
@@ -11,8 +11,6 @@ import { ProfileResponse } from '../../../types/profile'
 import { profileApi } from '../../../api/client/profile/profileApi'
 import { LinkButton } from '../../../components/component/Button/LoginPageButton'
 import Image from 'next/image'
-import { useSearchParams } from 'next/navigation'
-import AlertMessage from '../../../components/component/Alert/AlertMessage'
 import { useAuth } from '../../../contexts/AuthContext'
 import ProtectedRoute from '../../../components/ProtectedRoute'
 import { AccountRole } from '../../../types/account'
@@ -22,15 +20,6 @@ const ProfileDetail = () => {
   const [profile, setProfile] = useState<ProfileResponse | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
-  const [alert, setAlert] = useState({
-    status: 'success' as 'success' | 'error',
-    message: '',
-    isVisible: false,
-  })
-
-  // URLパラメータを取得
-  const searchParams = useSearchParams()
-  const success = searchParams.get('success')
 
   const userId = user?.uid || ''
 
@@ -91,10 +80,6 @@ const ProfileDetail = () => {
               </div>
             ) : (
               <>
-                {/* アラートメッセージを追加 */}
-                <div className="max-w-4xl mx-auto">
-                  <AlertMessage status={alert.status} message={alert.message} isVisible={alert.isVisible} />
-                </div>
                 {/* カード内 */}
                 <div className="max-w-4xl mx-auto p-8">
                   <div className="text-right pb-1 pr-8 mr-8">
@@ -107,10 +92,10 @@ const ProfileDetail = () => {
                     </div>
                     {/* プロフィールとメイン情報 */}
                     <div className="flex flex-col items-center mb-8">
-                      {profile.image_path ? (
+                      {profile.image_url ? (
                         <div className="w-40 h-40 rounded-full overflow-hidden mb-4">
                           <Image
-                            src={`${process.env.NEXT_PUBLIC_API_URL}${profile.image_path}`}
+                            src={profile.image_url}
                             alt="プロフィール画像"
                             width={160}
                             height={160}

--- a/front/src/types/profile.tsx
+++ b/front/src/types/profile.tsx
@@ -45,6 +45,7 @@ export type ProfileResponse = {
   admired_player: string | null
   introduction: string | null
   image_path: string | null
+  image_url: string | null
   created_at: string
   updated_at: string
 }


### PR DESCRIPTION
## 実装前の課題
* バックエンド側のディレクトリで保存している状態ではデプロイした環境では画像機能が動かない。

## 実現したいこと
* デプロイした際にプロフィール作成で保存した画像を表示させたい。

## 実装内容
* FirebaseStorageを使用して画像を保存を行った。

## 主な修正箇所
* dockerファイルにFirebaseStorageのバケット内容とファイル名を記述
* configにFirebaseの設定を記述（その都度１から設定を記述するのはスペルミスが発生する可能性があるため、各ファイルではこちらからインポートして使用している。）
* requirements.tsxにfirebase_adminの情報を記述（バックエンドからFirebaseのサービスにアクセスするために記述）
* .gitignoreにFirebaseファイルを記述
* firebase.pyを作成してFirebase Adminの初期化のコードを記述
* next.config.mjsで/ Firebase Storageからの画像取得を許可するためのコードを記述
* utils/image.pyの修正
* schemas/profile.pyの修正
* endpoint/profile.pyの修正
* CreateProfile, EditProfile, ProfileDetailの修正
* types/profile.tsxの修正

## 実装後どういった機能になったか
*  FirebaseStorageを使用してFirebaseに保存する場所を作成し、選択した画像を保存している
* データベースに画像のパスを保存している。
* 画像を取得したい際は、データベースに保存しているパスをFirebaseStorageから一致するものを取得してそのパスを元にURLを生成し、フロントエンドにURLをリターンしている

## 改善した内容
* バックエンドに直接選択した画像を保存するのではなく、Firebaseに選択した画像を保存し、データベースにパスを保存することでデプロイした環境でも画像を保存、取得することが可能になった。


## 動作確認
* 問題なくコンテナが動作し、NextjsとFastApiの画面が表示される
* 問題なくアカウント作成、ログイン、プロフィール作成、編集、詳細画面の表示、トレーニングメニューの追加、詳細画面の表示が起動している。