### PR TITLE
変数名user_idからfirebase_uidに変更、プロフィール画像の削除機能を実装しました。

### DIFF
--- a/front/src/api/client/profile/profileApi.tsx
+++ b/front/src/api/client/profile/profileApi.tsx
@@ -104,7 +104,9 @@ export const profileApi = {
       if (data.player_position !== undefined) formData.append('player_position', data.player_position)
       if (data.admired_player !== undefined) formData.append('admired_player', data.admired_player)
       if (data.introduction !== undefined) formData.append('introduction', data.introduction)
-      if (data.image instanceof File) {
+      // 画像削除フラグがtrueの場合、それを送信
+      if (data.delete_image !== undefined) formData.append('delete_image', data.delete_image.toString())
+      if (data.image) {
         formData.append('image', data.image)
       }
 

--- a/front/src/app/Player/CreateProfile/page.tsx
+++ b/front/src/app/Player/CreateProfile/page.tsx
@@ -24,6 +24,7 @@ const CreateProfile = () => {
   const fileInputRef = useRef<HTMLInputElement>(null)
   const [imagePreview, setImagePreview] = useState<string | null>(null)
   const [isCompleted, setIsCompleted] = useState<true | null>(null)
+  const [deleteImage, setDeleteImage] = useState<boolean>(false)
   const [formData, setFormData] = useState<CreateProfileRequest>({
     firebase_uid: user?.uid || '', // Firebaseのユーザーuid
     name: '',
@@ -153,6 +154,16 @@ const CreateProfile = () => {
       setImagePreview(imageUrl)
     }
   }
+
+  const handleDeleteImage = () => {
+    if (window.confirm('プロフィールを削除しますか？')) {
+      setDeleteImage(true)
+      setImagePreview(null)
+      const fileInput = document.getElementById('profileImageInput') as HTMLInputElement
+      if (fileInput) fileInput.value = ''
+    }
+  }
+
   // instanceof を使って、Dateであった場合に文字列に変換
   const formatDateForInput = (dateValue: Date | string): string => {
     if (dateValue instanceof Date) {
@@ -226,10 +237,37 @@ const CreateProfile = () => {
                           accept="image/*" //選択できるファイルを画像ファイルのみに制限
                           onChange={handleImageChange}
                           className="hidden"
+                          id="profileImageInput"
                         />
-                        <Buttons width="100px" type="button" onClick={handleImageSelect}>
-                          写真を選ぶ
-                        </Buttons>
+                        <div className="flex flex-justify-center space-x-3">
+                          <Buttons width="120px" type="button" onClick={handleImageSelect}>
+                            <span className="flex items-center">
+                              <svg className="w-4 h-4 mr-2" viewBox="0 0 20 20" fill="currentColor">
+                                <path
+                                  fillRule="evenodd"
+                                  d="M4 5a2 2 0 00-2 2v8a2 2 0 002 2h12a2 2 0 002-2V7a2 2 0 00-2-2h-1.586a1 1 0 01-.707-.293l-1.121-1.121A2 2 0 0011.172 3H8.828a2 2 0 00-1.414.586L6.293 4.707A1 1 0 015.586 5H4zm6 9a3 3 0 100-6 3 3 0 000 6z"
+                                  clipRule="evenodd"
+                                />
+                              </svg>
+                              写真を選ぶ
+                            </span>
+                          </Buttons>
+                          {imagePreview && (
+                            <Buttons width="90px" onClick={handleDeleteImage}>
+                              <span className="flex items-center">
+                                <svg className="w-4 h-4 mr-2" viewBox="0 0 20 20" fill="currentColor">
+                                  <path
+                                    fillRule="evenodd"
+                                    d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z"
+                                    clipRule="evenodd"
+                                  />
+                                </svg>
+                                削除
+                              </span>
+                            </Buttons>
+                          )}
+                        </div>
+
                         {validateError.image && <p className="text-red-500 text-sm mt-1">{validateError.image}</p>}
                       </div>
 

--- a/front/src/app/Player/EditProfile/page.tsx
+++ b/front/src/app/Player/EditProfile/page.tsx
@@ -45,7 +45,7 @@ const EditProfile = () => {
     message: '',
     isVisible: false,
   })
-
+  const [deleteImage, setDeleteImage] = useState<boolean>(false)
   const firebase_uid = user?.uid || ''
 
   // 未認証時のリダイレクト処理
@@ -94,6 +94,15 @@ const EditProfile = () => {
       fileInputRef.current.click()
     }
   }
+
+  const handleDeleteImage = () => {
+    if (window.confirm('プロフィールを削除しますか？')) {
+      setDeleteImage(true)
+      setImagePreview(null)
+      setImage(null)
+    }
+  }
+
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     // 画像のエラーをクリア
     setValidateError((prev) => ({
@@ -123,6 +132,7 @@ const EditProfile = () => {
     // フォームデータを収集
     const formData = {
       name,
+      firebase_uid: firebase_uid,
       birthday: new Date(birthday),
       team_name: teamName,
       player_dominant: playerDominant as DominantHand,
@@ -130,8 +140,8 @@ const EditProfile = () => {
       admired_player: admiredPlayer || '',
       introduction: introduction || '',
       image,
+      delete_image: deleteImage,
       // validateProfileの型に合わせるためにuser_idを追加
-      firebase_uid: firebase_uid,
     }
     const validationErrors = validateProfile(formData)
     if (image) {
@@ -165,6 +175,7 @@ const EditProfile = () => {
         admired_player: admiredPlayer ?? undefined,
         introduction: introduction ?? undefined,
         image: image,
+        delete_image: deleteImage,
       })
       setAlert({
         status: 'success',
@@ -305,9 +316,34 @@ const EditProfile = () => {
                         accept="image/*"
                         onChange={handleImageChange}
                       />
-                      <Buttons width="100px" onClick={handleImageClick}>
-                        写真を選ぶ
-                      </Buttons>
+                      <div className="flex flex-justify-center space-x-3">
+                        <Buttons width="120px" onClick={handleImageClick}>
+                          <span className="flex items-center">
+                            <svg className="w-4 h-4 mr-2" viewBox="0 0 20 20" fill="currentColor">
+                              <path
+                                fillRule="evenodd"
+                                d="M4 5a2 2 0 00-2 2v8a2 2 0 002 2h12a2 2 0 002-2V7a2 2 0 00-2-2h-1.586a1 1 0 01-.707-.293l-1.121-1.121A2 2 0 0011.172 3H8.828a2 2 0 00-1.414.586L6.293 4.707A1 1 0 015.586 5H4zm6 9a3 3 0 100-6 3 3 0 000 6z"
+                                clipRule="evenodd"
+                              />
+                            </svg>
+                            写真を選ぶ
+                          </span>
+                        </Buttons>
+                        {imagePreview && (
+                          <Buttons width="90px" onClick={handleDeleteImage}>
+                            <span className="flex items-center">
+                              <svg className="w-4 h-4 mr-2" viewBox="0 0 20 20" fill="currentColor">
+                                <path
+                                  fillRule="evenodd"
+                                  d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z"
+                                  clipRule="evenodd"
+                                />
+                              </svg>
+                              削除
+                            </span>
+                          </Buttons>
+                        )}
+                      </div>
                       {validateError.image && <p className="text-red-500 text-sm mt-1">{validateError.image}</p>}
                     </div>
 

--- a/front/src/app/Player/Home/page.tsx
+++ b/front/src/app/Player/Home/page.tsx
@@ -20,10 +20,10 @@ const PlayerHome = () => {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
-  const userId = user?.uid || ''
+  const firebase_uid = user?.uid || ''
 
   //ホームページを開いたらまずここの処理が動く。
-  //userIdでこちらのIdのプロフィール情報を取得する。
+  //firebase_uidでこちらのIdのプロフィール情報を取得する。
   //setHasProfile(!!profileData)でプロフィール情報が存在するかどうかの真偽を判定
   //存在する場合と存在しない場合を作成し、最終的にsetLoadingをfalseにする
   useEffect(() => {
@@ -31,7 +31,7 @@ const PlayerHome = () => {
       try {
         setLoading(true)
         setError(null)
-        const profileData = await profileApi.get(userId)
+        const profileData = await profileApi.get(firebase_uid)
         // プロフィールの存在チェックを改善
         if (profileData && profileData.id) {
           setHasProfile(true)
@@ -55,7 +55,7 @@ const PlayerHome = () => {
       }
     }
     checkProfile()
-  }, [userId])
+  }, [firebase_uid])
   return (
     <ProtectedRoute requiredRole={AccountRole.PLAYER} authRequired={true}>
       <div className="min-h-screen">

--- a/front/src/app/Player/ProfileDetail/page.tsx
+++ b/front/src/app/Player/ProfileDetail/page.tsx
@@ -21,10 +21,10 @@ const ProfileDetail = () => {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
 
-  const userId = user?.uid || ''
+  const firebase_uid = user?.uid || ''
 
   useEffect(() => {
-    if (!userId) {
+    if (!firebase_uid) {
       setLoading(false)
       return
     }
@@ -32,7 +32,7 @@ const ProfileDetail = () => {
     const fetchProfile = async () => {
       try {
         setLoading(true)
-        const data = await profileApi.get(userId)
+        const data = await profileApi.get(firebase_uid)
         setProfile(data)
         setError(null)
       } catch (error: any) {
@@ -42,10 +42,10 @@ const ProfileDetail = () => {
         setLoading(false)
       }
     }
-    if (userId) {
+    if (firebase_uid) {
       fetchProfile()
     }
-  }, [userId])
+  }, [firebase_uid])
 
   const formatBirthday = (dateString: string | undefined) => {
     if (!dateString) return ''

--- a/front/src/app/validation/useFormValidation.ts
+++ b/front/src/app/validation/useFormValidation.ts
@@ -81,8 +81,12 @@ export const validateProfile = (data: CreateProfileRequest): ProfilleValidationE
  * @returns エラーメッセージ。問題なければnull
  */
 
-export const validateImage = (file: File | null | undefined): string | null => {
-    if(!file) return null
+export const validateImage = (file: File | null | undefined): string | undefined => {
+    if(!file) return undefined
+
+    if(!(file instanceof File)) {
+        return "有効なファイルオブジェクトではありません。"
+    }
 
     if(file.size > 5 * 1024 * 1024) {
         return "画像のサイズは5MB以下を返してください"
@@ -91,5 +95,5 @@ export const validateImage = (file: File | null | undefined): string | null => {
     if(!file.type.startsWith('image/')) {
         return "画像ファイルを選択してください"
     }
-    return null
+    return undefined
 }

--- a/front/src/types/profile.tsx
+++ b/front/src/types/profile.tsx
@@ -32,6 +32,7 @@ export type CreateProfileRequest = {
   admired_player?: string
   introduction?: string
   image?: File | null
+  delete_image?: boolean
 }
 
 export type ProfileResponse = {


### PR DESCRIPTION
## 実装前の課題
- プレイヤー側のホーム画面とプロフィール詳細画面の変数名user_idが名前と実際の中身の値が一致していなかった。
- プロフィール画像を登録してから、削除したい時の削除機能がなかった（プロフィール画像は任意項目である）

## 実現したいこと
- 変数名を見ただけで、中身がどういった値なのかがわかるようにしたい。
- プロフィール画像を削除したい

## 主な修正箇所
### profileApi.tsx

- 修正でdelete_imageがtrueの場合の処理を記述して、エンドポイントにdelete_imageがtrueだという情報をリクエストできるように修正を行いました。

### CreateProfile/page.tsx
- CreateProfile/page.tsxで、削除ボタンを作成してクリックした際に、imageのインプット欄のvalueを空にして、useStateで作成しているsetImagePreviewをnullにする機能を作成しました。
- 写真を選ぶボタンと削除ボタンとで区別をはっきりするために、画像を挿入しました。
###  EditProfile/page.tsx
- 送信するformDataにuseStateを使用してdeleteImageをbooleanの型定義で初期値をfalseで作成し、削除ボタンをクリックした際に、trueに変更されるように作成しております。
- こちらの削除ボタンも作成画面同様に、useStateを使用して状態管理をしているimageとimagePreviewをクリックした際に、nullに変更できるように作成しております。
- 写真を選ぶボタンと削除ボタンとで区別をはっきりするために、画像を挿入しました。
###  Player/Home/page.tsx
- 変数名をuser_idからfirebase_uidに変更を行っております。
###  Player/ProfileDetail/page.tsx
- 変数名をuser_idからfirebase_uidに変更を行っております。
### useFormValidation.ts
- データをバックエンドに送信する際に、profileApi.tsxで送信するimageがFile型で合っていか確認する処理を行なっていたが、その処理を useFormValidation.tsにまとめました。
### type/profile.tsx
- delete_imageカラムを追加しました。

## 実装後どういった機能になったか
- プロフィール作成時に、選択した画像を削除することができる。
- プロフィールを編集する際に、一度登録した画像を削除することができる。

## 改善した内容
- 登録した画像を削除することができるようになり、かつ物理削除を使用しているので、FirebaseStorageで無駄な画像が溜まっていくことがない。
- 変数名をfirebase_uidにすることで、この変数にはfirebase_uidが入っているということがわかるようになった

## その他

- バックエンドでの処理について、プロフィールのCRUDを実装した際に、作成しておりました。そのため、今回はフロントエンドのみを実装しております。

## 動作確認

- 問題なくコンテナが動作し、NextjsとFastApiの画面が表示される
- 問題なくアカウント作成、ログイン、プロフィール作成、編集、詳細画面の表示が起動している。