### PR TITLE
Feature/login display edit

### DIFF
--- a/back/app/api/endpoints/auth.py
+++ b/back/app/api/endpoints/auth.py
@@ -3,7 +3,13 @@ from sqlalchemy.orm import Session
 from typing import Annotated
 
 from app.core.database import get_db
-from app.schemas.auth import UserCreate, UserResponse, UserRoleResponse, UserEmailUpdate
+from app.schemas.auth import (
+    UserCreate,
+    UserResponse,
+    UserRoleResponse,
+    UserEmailUpdate,
+    EmailExistsRequest,
+)
 from app.crud import user as user_crud
 
 import logging
@@ -85,3 +91,14 @@ def update_user_email_endpoint(
         db, email_update.firebase_uid, email_update.new_email
     )
     return updated_user
+
+
+@router.post("/users/email-exists", status_code=status.HTTP_200_OK)
+def check_email_exists(
+    email_req: EmailExistsRequest, db: Annotated[Session, Depends(get_db)]
+):
+    """指定されたメールアドレスが既に存在するかをチェックする"""
+    existing_user = user_crud.get_user_by_email(db, email_req.email)
+    # existing_user is not None は、ユーザーが見つかった場合に True、見つからなかった場合に False となります
+    # 戻り値は {"exists": True} または {"exists": False} というJSON形式になります
+    return {"exists": existing_user is not None}

--- a/back/app/crud/user.py
+++ b/back/app/crud/user.py
@@ -32,3 +32,12 @@ def update_user_role(db: Session, user_id: UUID, role: int):
         db.commit()
         db.refresh(db_user)
     return db_user
+
+
+def update_user_email(db: Session, firebase_uid: str, new_email: str):
+    db_user = get_user_by_firebase_uid(db, firebase_uid)
+    if db_user:
+        db_user.email = new_email
+        db.commit()
+        db.refresh(db_user)
+    return db_user

--- a/back/app/schemas/auth.py
+++ b/back/app/schemas/auth.py
@@ -31,3 +31,7 @@ class UserRoleResponse(BaseModel):
 class UserEmailUpdate(BaseModel):
     firebase_uid: str
     new_email: EmailStr
+
+
+class EmailExistsRequest(BaseModel):
+    email: EmailStr

--- a/back/app/schemas/auth.py
+++ b/back/app/schemas/auth.py
@@ -26,3 +26,8 @@ class UserRoleResponse(BaseModel):
 
     class Config:
         from_attributes = True
+
+
+class UserEmailUpdate(BaseModel):
+    firebase_uid: str
+    new_email: EmailStr

--- a/front/src/app/Coach/EditLogin/page.tsx
+++ b/front/src/app/Coach/EditLogin/page.tsx
@@ -1,16 +1,79 @@
-import React from 'react'
+'use client'
+
+import React, { ChangeEvent, FormEvent, useState } from 'react'
 
 import { Header } from '../../../components/component/Header/Header'
 import { Footer } from '../../../components/component/Footer/Footer'
-import { FormInput } from '../../../components/component/Input/FormInput'
 import { PageTitle } from '../../../components/component/Title/PageTitle'
 import { Label } from '../../../components/component/Label/Label'
 import { Card } from '../../../components/component/Card/Card'
 import { LinkButtons } from '../../../components/component/Button/LinkButtons'
 import ProtectedRoute from '../../../components/ProtectedRoute'
 import { AccountRole } from '../../../types/account'
+import { useAuth } from '../../../contexts/AuthContext'
+import { useRouter } from 'next/navigation'
+import { formDataValidationErrors, validateLoginEdit } from '../../../app/validation/loginValidation'
+import { updateUserPassword } from '../../../app/services/auth'
+import { FullInput } from '../../../components/component/Input/FullInput'
+import { InfoItem } from '../../../components/component/InfoItem/InfoItem'
+import { Buttons } from '../../../components/component/Button/Button'
 
 const EditLogin = () => {
+  const { user } = useAuth()
+  const router = useRouter()
+
+  const [formData, setFormData] = useState({
+    currentPassword: '',
+    newPassword: '',
+    confirmPassword: '',
+  })
+  const [errors, setErrors] = useState<{ [key: string]: string }>({})
+  const [validateErrors, setValidateError] = useState<formDataValidationErrors>({})
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [message, setMessage] = useState({ type: '', text: '' })
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
+    const { name, value } = e.target
+
+    if (errors[name]) {
+      setErrors((prev) => ({ ...prev, [name]: '' }))
+    }
+
+    setFormData((prev) => ({ ...prev, [name]: value }))
+  }
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+
+    const validate = validateLoginEdit(formData)
+    if (Object.keys(validate).length > 0) {
+      setValidateError(validate)
+      return
+    }
+
+    setIsSubmitting(true)
+    setMessage({ type: '', text: '' })
+
+    try {
+      await updateUserPassword(formData.currentPassword, formData.newPassword)
+
+      setMessage({
+        type: 'success',
+        text: 'パスワードが正常に更新されました',
+      })
+      alert('パスワードの変更に成功しました')
+      router.push('/Player/LoginDetail')
+    } catch (error: any) {
+      console.error('更新エラー', error)
+      setMessage({
+        type: 'error',
+        text: error.message || '更新中にエラーが発生しました',
+      })
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
   return (
     <ProtectedRoute requiredRole={AccountRole.COACH} authRequired={true}>
       <div className="min-h-screen flex flex-col">
@@ -18,31 +81,62 @@ const EditLogin = () => {
 
         <main className="flex-1 flex flex-col items-center p-6 w-full">
           <Card>
-            <PageTitle>ログイン情報変更</PageTitle>
+            <PageTitle>パスワード変更画面</PageTitle>
             <div className="max-w-4xl mx-auto p-8">
               <div className="text-right pr-5 mr-5">
                 <p className="text-2xl mt-3">指導者</p>
               </div>
 
-              <form className="bg-gray-100 p-8 rounded-lg shadow-md w-full max-w-md mt-6">
+              <form className="bg-gray-100 p-8 rounded-lg shadow-md w-full max-w-md mt-6" onSubmit={handleSubmit}>
                 <div className="mb-6">
-                  <Label>メールアドレス：</Label>
-                  <FormInput value="email" placeholder="メールアドレスを入力してください" />
+                  <Label>現在のパスワード（必須）</Label>
+                  <FullInput
+                    name="currentPassword"
+                    type="password"
+                    value={formData.currentPassword}
+                    onChange={handleChange}
+                  />
+                  {validateErrors.currentPassword && (
+                    <p className="text-red-500 text-sm mt-1">{validateErrors.currentPassword}</p>
+                  )}
+                  {message.text && <div className="text-red-500 text-sm mt-1">{message.text}</div>}
                 </div>
 
                 <div className="mb-6">
-                  <Label>パスワード：</Label>
-                  <FormInput value="number" placeholder="パスワードを入力してください" type="password" />
+                  <InfoItem
+                    label="現在のメールアドレス"
+                    value={user?.email || '(読み込み中...)'}
+                    className="md:w-96"
+                    type="text"
+                  />
                 </div>
 
                 <div className="mb-6">
-                  <Label>確認用パスワード：</Label>
-                  <FormInput value="number" placeholder="パスワードを入力してください" type="password" />
+                  <Label>新しいパスワード</Label>
+                  <FullInput name="newPassword" type="password" value={formData.newPassword} onChange={handleChange} />
+                  {validateErrors.newPassword && (
+                    <p className="text-red-500 text-sm mt-1">{validateErrors.newPassword}</p>
+                  )}
+                </div>
+
+                <div className="mb-6">
+                  <Label>新しいパスワード（確認）</Label>
+                  <FullInput
+                    name="confirmPassword"
+                    type="password"
+                    value={formData.confirmPassword}
+                    onChange={handleChange}
+                  />
+                  {validateErrors.confirmPassword && (
+                    <p className="text-red-500 text-sm mt-1">{validateErrors.confirmPassword}</p>
+                  )}
                 </div>
 
                 <div className="flex justify-center gap-4 mt-10">
-                  <LinkButtons href="/Coach/LoginDetail">ログイン情報詳細画面に戻る</LinkButtons>
-                  <LinkButtons href="/Coach/LoginDetail">決定</LinkButtons>
+                  <LinkButtons href="/Player/LoginDetail">ログイン情報詳細画面に戻る</LinkButtons>
+                  <Buttons type="submit" disabled={isSubmitting}>
+                    {isSubmitting ? '更新中...' : '更新する'}
+                  </Buttons>
                 </div>
               </form>
             </div>

--- a/front/src/app/Coach/EditLogin/page.tsx
+++ b/front/src/app/Coach/EditLogin/page.tsx
@@ -41,6 +41,15 @@ const EditLogin = () => {
       [name]: undefined,
     }))
 
+    // 関連するエラーメッセージをクリア
+    if (name === 'newPassword' || name === 'confirmPassword') {
+      setPasswordMessage({ type: '', text: '' })
+    }
+
+    if (name === 'newEmail' || name === 'confirmEmail') {
+      setEmailMessage({ type: '', text: '' })
+    }
+
     setFormData((prev) => ({ ...prev, [name]: value }))
   }
 
@@ -53,92 +62,145 @@ const EditLogin = () => {
       return
     }
 
+    // バリデーションチェック
     const validate = validateLoginEdit(formData)
     if (Object.keys(validate).length > 0) {
       setValidateError(validate)
       return
     }
 
-    if (!passwordMessage && !emailMessage) {
-      alert('変更箇所がありません')
-      return
-    }
-
     setIsSubmitting(true)
+    setPasswordMessage({ type: '', text: '' })
+    setEmailMessage({ type: '', text: '' })
 
-    let passwordSuccess = false
-    let emailSuccess = false
-
-    if (formData.newEmail) {
-      try {
+    try {
+      // メールアドレスとパスワードの両方を変更する場合
+      if (formData.newEmail && formData.newPassword) {
+        // 一連の処理として実行
         await updateUserEmail(formData.currentPassword, formData.newEmail)
+        await updateUserPassword(formData.currentPassword, formData.newPassword)
 
+        // 両方成功した場合のメッセージ設定
         setEmailMessage({
           type: 'success',
-          text: '現在のメールアドレス宛に確認メールを送信しました。メール内のリンクをクリックして変更プロセスを続けてください',
+          text: '新しいメールアドレス宛に確認メールを送信しました。メール内のリンクをクリックして変更を完了してください',
         })
-        // ユーザーに明示的な確認を促す
-        alert(`
-          新しいメールアドレス(${formData.newEmail})宛に確認メールを送信しました。
-          数分以内にメールが届かない場合は、再度お試しいただくか、別のメールアドレスをお試しください。
-          迷惑メールフォルダも確認してください。
-          メールをクリックした後、再度ローディングを行なってから、新しいメールアドレスでログインをしてください
-        `)
-        emailSuccess = true
-      } catch (error: any) {
-        console.error('メールアドレス更新エラー', error)
-        setEmailMessage({
-          type: 'error',
-          text: error.message || 'メール送信中にエラーが発生しました',
-        })
-      }
-    }
-    if (formData.newPassword) {
-      try {
-        await updateUserPassword(formData.currentPassword, formData.newPassword)
         setPasswordMessage({
           type: 'success',
           text: 'パスワードが正常に更新されました',
         })
-        passwordSuccess = true
-      } catch (error: any) {
-        console.error('パスワード更新エラー', error)
+
+        // 成功メッセージ表示
+        alert(`
+          パスワードの変更に成功しました。
+          メールアドレス変更のため、新しいメールアドレス宛に確認メールを送信しました。
+          メール内のリンクをクリックして変更を完了してください。
+        `)
+
+        // フォームリセットとページ遷移
+        setFormData({
+          currentPassword: '',
+          newPassword: '',
+          confirmPassword: '',
+          newEmail: '',
+          confirmEmail: '',
+        })
+
+        setTimeout(() => {
+          router.push('/Coach/LoginDetail')
+        }, 1000)
+      }
+      // メールアドレスのみ変更
+      else if (formData.newEmail) {
+        await updateUserEmail(formData.currentPassword, formData.newEmail)
+
+        setEmailMessage({
+          type: 'success',
+          text: '新しいメールアドレス宛に確認メールを送信しました。メール内のリンクをクリックして変更を完了してください',
+        })
+
+        alert(`
+          新しいメールアドレス(${formData.newEmail})宛に確認メールを送信しました。
+          メール内のリンクをクリックして変更を完了してください。
+        `)
+
+        // フォームリセットとページ遷移
+        setFormData({
+          currentPassword: '',
+          newPassword: '',
+          confirmPassword: '',
+          newEmail: '',
+          confirmEmail: '',
+        })
+
+        setTimeout(() => {
+          router.push('/Coach/LoginDetail')
+        }, 1000)
+      }
+      // パスワードのみ変更
+      else if (formData.newPassword) {
+        await updateUserPassword(formData.currentPassword, formData.newPassword)
+
+        setPasswordMessage({
+          type: 'success',
+          text: 'パスワードが正常に更新されました',
+        })
+
+        alert('パスワードの変更に成功しました。')
+
+        // フォームリセットとページ遷移
+        setFormData({
+          currentPassword: '',
+          newPassword: '',
+          confirmPassword: '',
+          newEmail: '',
+          confirmEmail: '',
+        })
+
+        setTimeout(() => {
+          router.push('/Coach/LoginDetail')
+        }, 1000)
+      }
+    } catch (error: any) {
+      console.error('更新エラー:', error)
+
+      // エラーメッセージの設定
+      if (error.message && error.message.includes('メールアドレス')) {
+        setEmailMessage({
+          type: 'error',
+          text: error.message || 'メールアドレス更新中にエラーが発生しました',
+        })
+      } else if (error.message && error.message.includes('パスワード')) {
         setPasswordMessage({
           type: 'error',
           text: error.message || 'パスワード更新中にエラーが発生しました',
         })
+      } else {
+        // エラーの種類が特定できない場合
+        if (formData.newEmail && formData.newPassword) {
+          // 両方変更しようとしていた場合は両方にエラーメッセージを表示
+          setEmailMessage({
+            type: 'error',
+            text: '更新処理中にエラーが発生しました',
+          })
+          setPasswordMessage({
+            type: 'error',
+            text: '更新処理中にエラーが発生しました',
+          })
+        } else if (formData.newEmail) {
+          setEmailMessage({
+            type: 'error',
+            text: error.message || 'メールアドレス更新中にエラーが発生しました',
+          })
+        } else if (formData.newPassword) {
+          setPasswordMessage({
+            type: 'error',
+            text: error.message || 'パスワード更新中にエラーが発生しました',
+          })
+        }
       }
-    }
-
-    setIsSubmitting(false)
-
-    if (passwordSuccess || emailSuccess) {
-      let message = ''
-
-      if (passwordSuccess) {
-        message += 'パスワードの変更に成功しました。'
-      }
-
-      if (emailSuccess) {
-        message +=
-          'メールアドレス変更のため、新しいメールアドレス宛に確認メールを送信しました。メール内のリンクをクリックして変更を完了してください。'
-      }
-
-      alert(message)
-
-      // フォームをリセット
-      setFormData({
-        currentPassword: '',
-        newPassword: '',
-        confirmPassword: '',
-        newEmail: '',
-        confirmEmail: '',
-      })
-
-      // 明示的にタイムアウトを設定してページ遷移
-      setTimeout(() => {
-        router.push('/Coach/LoginDetail')
-      }, 1000)
+    } finally {
+      setIsSubmitting(false)
     }
   }
 

--- a/front/src/app/Coach/LoginDetail/page.tsx
+++ b/front/src/app/Coach/LoginDetail/page.tsx
@@ -42,7 +42,7 @@ const LoginDetail = () => {
                 </div>
 
                 <div className="text-right pt-5">
-                  <LinkButtons href="/Coach/EditLogin">編集</LinkButtons>
+                  <LinkButtons href="/Coach/EditLogin">ログイン情報を変更</LinkButtons>
                 </div>
               </form>
             </div>

--- a/front/src/app/Coach/LoginDetail/page.tsx
+++ b/front/src/app/Coach/LoginDetail/page.tsx
@@ -1,3 +1,4 @@
+'use client'
 import React from 'react'
 
 import { Header } from '../../../components/component/Header/Header'
@@ -8,8 +9,12 @@ import { Card } from '../../../components/component/Card/Card'
 import { LinkButtons } from '../../../components/component/Button/LinkButtons'
 import ProtectedRoute from '../../../components/ProtectedRoute'
 import { AccountRole } from '../../../types/account'
+import { useAuth } from '../../../contexts/AuthContext'
 
 const LoginDetail = () => {
+  const { user } = useAuth()
+  const firebaseUser = user
+
   return (
     <ProtectedRoute requiredRole={AccountRole.COACH} authRequired={true}>
       <div className="min-h-screen flex flex-col">
@@ -24,11 +29,16 @@ const LoginDetail = () => {
               </div>
               <form className="bg-gray-100 p-8 rounded-lg shadow-md w-full max-w-md mt-6">
                 <div className="mb-6">
-                  <InfoItem label="現在のメールアドレス：" value="tatara@emai.com" className="md:w-96" />
+                  <InfoItem
+                    label="現在のメールアドレス："
+                    value={firebaseUser?.email || '(読み込み中...)'}
+                    className="md:w-96"
+                  />
                 </div>
 
                 <div className="mb-6">
-                  <InfoItem label="現在のパスワード：" value="1212121212" className="md:w-96" />
+                  <InfoItem label="現在のパスワード：" value="・・・・" className="md:w-96" type="number" />
+                  <p className="text-sum text-gray-500 mt-1">セキュリティ上の理由により表示されません</p>
                 </div>
 
                 <div className="text-right pt-5">

--- a/front/src/app/Player/EditLogin/page.tsx
+++ b/front/src/app/Player/EditLogin/page.tsx
@@ -12,32 +12,39 @@ import ProtectedRoute from '../../../components/ProtectedRoute'
 import { AccountRole } from '../../../types/account'
 import { useAuth } from '../../../contexts/AuthContext'
 import { useRouter } from 'next/navigation'
-import { updateUserPassword } from '../../../app/services/auth'
+import { updateUserEmail, updateUserPassword } from '../../../app/services/auth'
 import { FullInput } from '../../../components/component/Input/FullInput'
 import { Buttons } from '../../../components/component/Button/Button'
-import { InfoItem } from '../../../components/component/InfoItem/InfoItem'
-import { formDataValidationErrors, validateLoginEdit } from '../../../app/validation/loginValidation'
+import {
+  LoginInfoFormData,
+  LoginInfoValidationErrors,
+  validateLoginEdit,
+} from '../../../app/validation/loginValidation'
 
 const EditLogin = () => {
   const { user } = useAuth()
   const router = useRouter()
 
-  const [formData, setFormData] = useState({
+  const [formData, setFormData] = useState<LoginInfoFormData>({
     currentPassword: '',
     newPassword: '',
     confirmPassword: '',
+    newEmail: '',
+    confirmEmail: '',
   })
-  const [errors, setErrors] = useState<{ [key: string]: string }>({})
-  const [validateErrors, setValidateError] = useState<formDataValidationErrors>({})
+  const [validateErrors, setValidateError] = useState<LoginInfoValidationErrors>({})
   const [isSubmitting, setIsSubmitting] = useState(false)
-  const [message, setMessage] = useState({ type: '', text: '' })
+  const [passwordMessage, setPasswordMessage] = useState({ type: '', text: '' })
+  const [emailMessage, setEmailMessage] = useState({ type: '', text: '' })
 
   const handleChange = (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
     const { name, value } = e.target
 
-    if (errors[name]) {
-      setErrors((prev) => ({ ...prev, [name]: '' }))
-    }
+    // エラーをクリア
+    setValidateError((prev) => ({
+      ...prev,
+      [name]: undefined,
+    }))
 
     setFormData((prev) => ({ ...prev, [name]: value }))
   }
@@ -51,26 +58,93 @@ const EditLogin = () => {
       return
     }
 
+    // 何も変更がない場合
+    if (!formData.newPassword && !formData.newEmail) {
+      alert('変更する項目がありません')
+      return
+    }
+
     setIsSubmitting(true)
-    setMessage({ type: '', text: '' })
 
-    try {
-      await updateUserPassword(formData.currentPassword, formData.newPassword)
+    // 成功フラグ
+    let passwordSuccess = false
+    let emailSuccess = false
 
-      setMessage({
-        type: 'success',
-        text: 'パスワードが正常に更新されました',
+    // メールアドレス変更処理
+    if (formData.newEmail) {
+      try {
+        // sendEmailChangeVerification の代わりに updateUserEmail を使用
+        await updateUserEmail(formData.currentPassword, formData.newEmail)
+
+        setEmailMessage({
+          type: 'success',
+          text: '現在のメールアドレス宛に確認メールを送信しました。メール内のリンクをクリックして変更プロセスを続けてください',
+        })
+        // ユーザーに明示的な確認を促す
+        alert(`
+          新しいメールアドレス(${formData.newEmail})宛に確認メールを送信しました。
+          数分以内にメールが届かない場合は、再度お試しいただくか、別のメールアドレスをお試しください。
+          迷惑メールフォルダも確認してください。
+          メールをクリックした後、再度ローディングを行なってから、新しいメールアドレスでログインをしてください
+        `)
+        emailSuccess = true
+      } catch (error: any) {
+        console.error('メールアドレス更新エラー', error)
+        setEmailMessage({
+          type: 'error',
+          text: error.message || 'メール送信中にエラーが発生しました',
+        })
+      }
+    }
+
+    // パスワード変更処理
+    if (formData.newPassword) {
+      try {
+        await updateUserPassword(formData.currentPassword, formData.newPassword)
+        setPasswordMessage({
+          type: 'success',
+          text: 'パスワードが正常に更新されました',
+        })
+        passwordSuccess = true
+      } catch (error: any) {
+        console.error('パスワード更新エラー', error)
+        setPasswordMessage({
+          type: 'error',
+          text: error.message || 'パスワード更新中にエラーが発生しました',
+        })
+      }
+    }
+
+    // 全ての処理が完了したら
+    setIsSubmitting(false)
+
+    if (passwordSuccess || emailSuccess) {
+      let message = ''
+
+      if (passwordSuccess) {
+        message += 'パスワードの変更に成功しました。'
+      }
+
+      if (emailSuccess) {
+        message +=
+          'メールアドレス変更のため、新しいメールアドレス宛に確認メールを送信しました。メール内のリンクをクリックして変更を完了してください。'
+      }
+
+      alert(message)
+
+      // フォームをリセット
+      setFormData({
+        currentPassword: '',
+        newPassword: '',
+        confirmPassword: '',
+        newEmail: '',
+        confirmEmail: '',
       })
-      alert('パスワードの変更に成功しました')
-      router.push('/Player/LoginDetail')
-    } catch (error: any) {
-      console.error('更新エラー', error)
-      setMessage({
-        type: 'error',
-        text: error.message || '更新中にエラーが発生しました',
-      })
-    } finally {
-      setIsSubmitting(false)
+
+      // 明示的にタイムアウトを設定してページ遷移
+      setTimeout(() => {
+        router.push('/Player/LoginDetail')
+      }, 1000)
     }
   }
 
@@ -80,7 +154,7 @@ const EditLogin = () => {
         <Header role="player">ホーム画面</Header>
         <main className="flex-1 flex flex-col items-center p-6 w-full">
           <Card>
-            <PageTitle>パスワード変更画面</PageTitle>
+            <PageTitle>ログイン情報変更画面</PageTitle>
             <div className="max-w-4xl mx-auto p-8">
               <div className="text-right pr-5 mr-5">
                 <p className="text-2xl mt-3">選手</p>
@@ -98,16 +172,6 @@ const EditLogin = () => {
                   {validateErrors.currentPassword && (
                     <p className="text-red-500 text-sm mt-1">{validateErrors.currentPassword}</p>
                   )}
-                  {message.text && <div className="text-red-500 text-sm mt-1">{message.text}</div>}
-                </div>
-
-                <div className="mb-6">
-                  <InfoItem
-                    label="現在のメールアドレス"
-                    value={user?.email || '(読み込み中...)'}
-                    className="md:w-96"
-                    type="text"
-                  />
                 </div>
 
                 <div className="mb-6">
@@ -129,6 +193,52 @@ const EditLogin = () => {
                   {validateErrors.confirmPassword && (
                     <p className="text-red-500 text-sm mt-1">{validateErrors.confirmPassword}</p>
                   )}
+                  {passwordMessage.text && (
+                    <div
+                      className={`p-3 mb-4 rounded ${
+                        passwordMessage.type === 'error' ? 'bg-red-100 text-red-700' : 'bg-green-100 text-green-700'
+                      }`}
+                    >
+                      {passwordMessage.text}
+                    </div>
+                  )}
+                </div>
+
+                <div className="border-t border-gray-300 my-6 pt-6">
+                  <h3 className="text-lg font-semibold mb-4">メールアドレス変更</h3>
+
+                  <div className="mb-6">
+                    <Label>現在のメールアドレス</Label>
+                    <p className="py-2 px-3 bg-gray-200 rounded">{user?.email || '(読み込み中...)'}</p>
+                  </div>
+
+                  <div className="mb-6">
+                    <Label>新しいメールアドレス</Label>
+                    <FullInput name="newEmail" type="email" value={formData.newEmail} onChange={handleChange} />
+                    {validateErrors.newEmail && <p className="text-red-500 text-sm mt-1">{validateErrors.newEmail}</p>}
+                  </div>
+                  <div className="mb-6">
+                    <Label>新しいメールアドレス（確認）</Label>
+                    <FullInput name="confirmEmail" type="email" value={formData.confirmEmail} onChange={handleChange} />
+                    {validateErrors.confirmEmail && (
+                      <p className="text-red-500 text-sm mt-1">{validateErrors.confirmEmail}</p>
+                    )}
+                  </div>
+
+                  {emailMessage.text && (
+                    <div
+                      className={`p-3 mb-4 rounded ${
+                        emailMessage.type === 'error' ? 'bg-red-100 text-red-700' : 'bg-green-100 text-green-700'
+                      }`}
+                    >
+                      {emailMessage.text}
+                    </div>
+                  )}
+
+                  <p className="text-sm text-gray-600 mb-4">
+                    ※メールアドレスの変更は、新しいメールアドレス宛に確認メールが送信されます。
+                    メール内のリンクをクリックして変更を完了してください。
+                  </p>
                 </div>
 
                 <div className="flex justify-center gap-4 mt-10">

--- a/front/src/app/Player/EditLogin/page.tsx
+++ b/front/src/app/Player/EditLogin/page.tsx
@@ -1,47 +1,141 @@
-import React from 'react'
+'use client'
+
+import React, { ChangeEvent, FormEvent, useState } from 'react'
 
 import { Header } from '../../../components/component/Header/Header'
 import { Footer } from '../../../components/component/Footer/Footer'
-import { FormInput } from '../../../components/component/Input/FormInput'
 import { PageTitle } from '../../../components/component/Title/PageTitle'
 import { Label } from '../../../components/component/Label/Label'
 import { Card } from '../../../components/component/Card/Card'
 import { LinkButtons } from '../../../components/component/Button/LinkButtons'
 import ProtectedRoute from '../../../components/ProtectedRoute'
 import { AccountRole } from '../../../types/account'
+import { useAuth } from '../../../contexts/AuthContext'
+import { useRouter } from 'next/navigation'
+import { updateUserPassword } from '../../../app/services/auth'
+import { FullInput } from '../../../components/component/Input/FullInput'
+import { Buttons } from '../../../components/component/Button/Button'
+import { InfoItem } from '../../../components/component/InfoItem/InfoItem'
+import { formDataValidationErrors, validateLoginEdit } from '../../../app/validation/loginValidation'
 
 const EditLogin = () => {
+  const { user } = useAuth()
+  const router = useRouter()
+
+  const [formData, setFormData] = useState({
+    currentPassword: '',
+    newPassword: '',
+    confirmPassword: '',
+  })
+  const [errors, setErrors] = useState<{ [key: string]: string }>({})
+  const [validateErrors, setValidateError] = useState<formDataValidationErrors>({})
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [message, setMessage] = useState({ type: '', text: '' })
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
+    const { name, value } = e.target
+
+    if (errors[name]) {
+      setErrors((prev) => ({ ...prev, [name]: '' }))
+    }
+
+    setFormData((prev) => ({ ...prev, [name]: value }))
+  }
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+
+    const validate = validateLoginEdit(formData)
+    if (Object.keys(validate).length > 0) {
+      setValidateError(validate)
+      return
+    }
+
+    setIsSubmitting(true)
+    setMessage({ type: '', text: '' })
+
+    try {
+      await updateUserPassword(formData.currentPassword, formData.newPassword)
+
+      setMessage({
+        type: 'success',
+        text: 'パスワードが正常に更新されました',
+      })
+      alert('パスワードの変更に成功しました')
+      router.push('/Player/LoginDetail')
+    } catch (error: any) {
+      console.error('更新エラー', error)
+      setMessage({
+        type: 'error',
+        text: error.message || '更新中にエラーが発生しました',
+      })
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
   return (
     <ProtectedRoute requiredRole={AccountRole.PLAYER} authRequired={true}>
       <div className="min-h-screen flex flex-col">
         <Header role="player">ホーム画面</Header>
         <main className="flex-1 flex flex-col items-center p-6 w-full">
           <Card>
-            <PageTitle>ログイン情報変更</PageTitle>
+            <PageTitle>パスワード変更画面</PageTitle>
             <div className="max-w-4xl mx-auto p-8">
               <div className="text-right pr-5 mr-5">
                 <p className="text-2xl mt-3">選手</p>
               </div>
 
-              <form className="bg-gray-100 p-8 rounded-lg shadow-md w-full max-w-md mt-6">
+              <form className="bg-gray-100 p-8 rounded-lg shadow-md w-full max-w-md mt-6" onSubmit={handleSubmit}>
                 <div className="mb-6">
-                  <Label>メールアドレス：</Label>
-                  <FormInput value="email" placeholder="メールアドレスを入力してください" />
+                  <Label>現在のパスワード（必須）</Label>
+                  <FullInput
+                    name="currentPassword"
+                    type="password"
+                    value={formData.currentPassword}
+                    onChange={handleChange}
+                  />
+                  {validateErrors.currentPassword && (
+                    <p className="text-red-500 text-sm mt-1">{validateErrors.currentPassword}</p>
+                  )}
+                  {message.text && <div className="text-red-500 text-sm mt-1">{message.text}</div>}
                 </div>
 
                 <div className="mb-6">
-                  <Label>パスワード：</Label>
-                  <FormInput value="number" placeholder="パスワードを入力してください" type="password" />
+                  <InfoItem
+                    label="現在のメールアドレス"
+                    value={user?.email || '(読み込み中...)'}
+                    className="md:w-96"
+                    type="text"
+                  />
                 </div>
 
                 <div className="mb-6">
-                  <Label>パスワード（再入力）：</Label>
-                  <FormInput value="number" placeholder="パスワードを入力してください" type="password" />
+                  <Label>新しいパスワード</Label>
+                  <FullInput name="newPassword" type="password" value={formData.newPassword} onChange={handleChange} />
+                  {validateErrors.newPassword && (
+                    <p className="text-red-500 text-sm mt-1">{validateErrors.newPassword}</p>
+                  )}
+                </div>
+
+                <div className="mb-6">
+                  <Label>新しいパスワード（確認）</Label>
+                  <FullInput
+                    name="confirmPassword"
+                    type="password"
+                    value={formData.confirmPassword}
+                    onChange={handleChange}
+                  />
+                  {validateErrors.confirmPassword && (
+                    <p className="text-red-500 text-sm mt-1">{validateErrors.confirmPassword}</p>
+                  )}
                 </div>
 
                 <div className="flex justify-center gap-4 mt-10">
                   <LinkButtons href="/Player/LoginDetail">ログイン情報詳細画面に戻る</LinkButtons>
-                  <LinkButtons href="/Player/LoginDetail">決定</LinkButtons>
+                  <Buttons type="submit" disabled={isSubmitting}>
+                    {isSubmitting ? '更新中...' : '更新する'}
+                  </Buttons>
                 </div>
               </form>
             </div>

--- a/front/src/app/Player/LoginDetail/page.tsx
+++ b/front/src/app/Player/LoginDetail/page.tsx
@@ -1,5 +1,5 @@
 'use client'
-import React, { useState } from 'react'
+import React from 'react'
 
 import { Header } from '../../../components/component/Header/Header'
 import { Footer } from '../../../components/component/Footer/Footer'
@@ -37,12 +37,12 @@ const LoginDetail = () => {
                 </div>
 
                 <div className="mb-6">
-                  <InfoItem label="現在のパスワード：" value="・・・・・・" className="md:w-96" type="password" />
+                  <InfoItem label="現在のパスワード：" value="・・・・" className="md:w-96" type="password" />
                   <p className="text-sum text-gray-500 mt-1">セキュリティ上の理由により表示されません</p>
                 </div>
 
                 <div className="text-right pt-5">
-                  <LinkButtons href="/Player/EditLogin">パスワード変更</LinkButtons>
+                  <LinkButtons href="/Player/EditLogin">ログイン情報を変更</LinkButtons>
                 </div>
               </form>
             </div>

--- a/front/src/app/Player/LoginDetail/page.tsx
+++ b/front/src/app/Player/LoginDetail/page.tsx
@@ -1,4 +1,5 @@
-import React from 'react'
+'use client'
+import React, { useState } from 'react'
 
 import { Header } from '../../../components/component/Header/Header'
 import { Footer } from '../../../components/component/Footer/Footer'
@@ -8,8 +9,12 @@ import { Card } from '../../../components/component/Card/Card'
 import { LinkButtons } from '../../../components/component/Button/LinkButtons'
 import { AccountRole } from '../../../types/account'
 import ProtectedRoute from '../../../components/ProtectedRoute'
+import { useAuth } from '../../../contexts/AuthContext'
 
 const LoginDetail = () => {
+  const { user } = useAuth()
+  const firebaseUser = user
+
   return (
     <ProtectedRoute requiredRole={AccountRole.PLAYER} authRequired={true}>
       <div className="min-h-screen flex flex-col">
@@ -23,15 +28,21 @@ const LoginDetail = () => {
               </div>
               <form className="bg-gray-100 p-8 rounded-lg w-full max-w-md mt-6">
                 <div className="mb-6">
-                  <InfoItem label="現在のメールアドレス：" value="tatara@emai.com" className="md:w-96" type="text" />
+                  <InfoItem
+                    label="現在のメールアドレス："
+                    value={firebaseUser?.email || '(読み込み中...)'}
+                    className="md:w-96"
+                    type="text"
+                  />
                 </div>
 
                 <div className="mb-6">
-                  <InfoItem label="現在のパスワード：" value="1212121212" className="md:w-96" type="password" />
+                  <InfoItem label="現在のパスワード：" value="・・・・・・" className="md:w-96" type="password" />
+                  <p className="text-sum text-gray-500 mt-1">セキュリティ上の理由により表示されません</p>
                 </div>
 
                 <div className="text-right pt-5">
-                  <LinkButtons href="/Player/EditLogin">編集</LinkButtons>
+                  <LinkButtons href="/Player/EditLogin">パスワード変更</LinkButtons>
                 </div>
               </form>
             </div>

--- a/front/src/app/services/auth.ts
+++ b/front/src/app/services/auth.ts
@@ -6,6 +6,7 @@ import {
     EmailAuthProvider,
     reauthenticateWithCredential,
     updatePassword,
+    verifyBeforeUpdateEmail,
 } from "firebase/auth";
 import type { UserCredential } from "firebase/auth"; // 型のみインポート
 
@@ -25,15 +26,6 @@ export const createAccount = async(
         // 1. Firebaseでユーザーを作成
         const userCredential = await createUserWithEmailAndPassword(auth, email, password);
         const user = userCredential.user
-
-        // 3. バックエンドにユーザー情報を保存
-
-        const requestBody = {
-            firebase_uid: user.uid,
-            email: user.email,
-            role: role,
-        };
-
 
         const response = await fetch(`${API_URL}/auth/users`, {//エンドポイントauthファイルのusersのパス
             method: 'POST',
@@ -159,3 +151,55 @@ export const updateUserPassword = async(currentPassword: string, newPassword: st
     }
 }
 
+export const updateUserEmail = async (
+  currentPassword: string,
+  newEmail: string
+): Promise<void> => {
+  try {
+    const user = auth.currentUser;
+    if (!user || !user.email) {
+      throw new Error("ログインしていないか、メールアドレスが取得できません。");
+    }
+    
+    // 1. 再認証
+    const credential = EmailAuthProvider.credential(user.email, currentPassword);
+    await reauthenticateWithCredential(user, credential);
+    
+    // 2. メール変更情報をローカルストレージに保存（AuthContext側で使用）
+    // 取り出すときにparseが必要です
+    localStorage.setItem('pendingEmailChange', JSON.stringify({
+      firebaseUid: user.uid,
+      newEmail: newEmail,
+      timestamp: Date.now(),
+    }));
+
+    // 3. Firebase側のメールアドレス更新前の確認メールを送信
+    await verifyBeforeUpdateEmail(user, newEmail);
+    
+    // 4. 成功メッセージをユーザーに表示
+    alert(`
+      新しいメールアドレス（${newEmail}）宛に確認メールを送信しました。
+      メール内のリンクをクリックして変更を完了してください。
+      変更完了後、自動的にシステムに反映されます。
+    `);
+
+    return;
+  } catch (error: any) {
+    console.error("メールアドレス更新エラー:", error);
+    
+    // エラーコードによる適切なメッセージ表示
+    if (error.code === "auth/requires-recent-login") {
+      throw new Error("セキュリティのため再度ログインが必要です。ログアウトして再度ログインしてください。");
+    } else if (error.code === "auth/email-already-in-use") {
+      throw new Error("このメールアドレスは既に使用されています。");
+    } else if (error.code === "auth/invalid-email") {
+      throw new Error("メールアドレスの形式が正しくありません。");
+    } else if (error.code === "auth/invalid-credential") {
+      throw new Error("現在のパスワードが正しくありません。");
+    } else if (error.code === "auth/operation-not-allowed") {
+      throw new Error("この操作は現在許可されていません。しばらく経ってから再度お試しください。");
+    } else {
+      throw new Error(`メールアドレスの更新に失敗しました: ${error.message || "不明なエラー"}`);
+    }
+  }
+};

--- a/front/src/app/services/auth.ts
+++ b/front/src/app/services/auth.ts
@@ -194,14 +194,6 @@ export const updateUserEmail = async (
     // 1. 再認証
     const credential = EmailAuthProvider.credential(user.email, currentPassword);
     await reauthenticateWithCredential(user, credential);
-    
-    // 2. メール変更情報をローカルストレージに保存（AuthContext側で使用）
-    // 取り出すときにparseが必要です
-    localStorage.setItem('pendingEmailChange', JSON.stringify({
-      firebaseUid: user.uid,
-      newEmail: newEmail,
-      timestamp: Date.now(),
-    }));
 
     // 3. Firebase側のメールアドレス更新前の確認メールを送信
     await verifyBeforeUpdateEmail(user, newEmail);

--- a/front/src/app/validation/loginValidation.ts
+++ b/front/src/app/validation/loginValidation.ts
@@ -1,0 +1,31 @@
+type formDataType = {
+    currentPassword: string,
+    newPassword: string,
+    confirmPassword: string,
+}
+
+export type formDataValidationErrors = {
+    currentPassword?: string ,
+    newPassword?: string,
+    confirmPassword?: string,
+}
+
+
+export const validateLoginEdit = (formData: formDataType): formDataValidationErrors => {
+    const newErrors: formDataValidationErrors = {}
+
+    if (!formData.currentPassword) {
+      newErrors.currentPassword = '現在のパスワードを入力してください'
+    }
+
+    if (!formData.newPassword) {
+      newErrors.newPassword = '新しいパスワードを入力してください'
+    } else if (formData.newPassword.length < 8) {
+      newErrors.newPassword = 'パスワードは8文字以上で入力してください'
+    }
+    if (formData.newPassword !== formData.confirmPassword) {
+      newErrors.confirmPassword = 'パスワードが一致しません'
+    }
+
+    return newErrors
+  }

--- a/front/src/app/validation/loginValidation.ts
+++ b/front/src/app/validation/loginValidation.ts
@@ -22,6 +22,8 @@ export const validateLoginEdit = (formData: LoginInfoFormData): LoginInfoValidat
     if (formData.newPassword || formData.confirmPassword) {
         if (!formData.currentPassword) {
             newErrors.currentPassword = '現在のパスワードを入力してください'
+        } else if (formData.currentPassword.length < 8) {
+          newErrors.currentPassword = "パスワードは8文字以上で入力してください"
         }
         
         if (formData.newPassword) {
@@ -39,6 +41,8 @@ export const validateLoginEdit = (formData: LoginInfoFormData): LoginInfoValidat
       if (formData.newEmail || formData.confirmEmail) {
         if (!formData.currentPassword) {
           newErrors.currentPassword = '現在のパスワードを入力してください'
+        } else if (formData.currentPassword.length < 8) {
+          newErrors.currentPassword = "パスワードは8文字以上で入力してください"
         }
         
         if (formData.newEmail) {

--- a/front/src/app/validation/loginValidation.ts
+++ b/front/src/app/validation/loginValidation.ts
@@ -1,31 +1,57 @@
-type formDataType = {
+export type LoginInfoFormData = {
     currentPassword: string,
     newPassword: string,
     confirmPassword: string,
+    newEmail: string,
+    confirmEmail: string,
 }
 
-export type formDataValidationErrors = {
+export type LoginInfoValidationErrors = {
     currentPassword?: string ,
     newPassword?: string,
     confirmPassword?: string,
+    newEmail?: string,
+    confirmEmail?: string,
 }
 
 
-export const validateLoginEdit = (formData: formDataType): formDataValidationErrors => {
-    const newErrors: formDataValidationErrors = {}
+export const validateLoginEdit = (formData: LoginInfoFormData): LoginInfoValidationErrors => {
+    const newErrors: LoginInfoValidationErrors = {}
 
-    if (!formData.currentPassword) {
-      newErrors.currentPassword = '現在のパスワードを入力してください'
-    }
-
-    if (!formData.newPassword) {
-      newErrors.newPassword = '新しいパスワードを入力してください'
-    } else if (formData.newPassword.length < 8) {
-      newErrors.newPassword = 'パスワードは8文字以上で入力してください'
-    }
-    if (formData.newPassword !== formData.confirmPassword) {
-      newErrors.confirmPassword = 'パスワードが一致しません'
-    }
-
+    // パスワード関連フィールドが入力されている場合のバリデーション
+    if (formData.newPassword || formData.confirmPassword) {
+        if (!formData.currentPassword) {
+            newErrors.currentPassword = '現在のパスワードを入力してください'
+        }
+        
+        if (formData.newPassword) {
+          if (formData.newPassword.length < 8) {
+            newErrors.newPassword = 'パスワードは8文字以上で入力してください'
+          }
+          
+          if (formData.newPassword !== formData.confirmPassword) {
+            newErrors.confirmPassword = 'パスワードが一致しません'
+          }
+        }
+      }
+      
+      // メールアドレス関連フィールドが入力されている場合のバリデーション
+      if (formData.newEmail || formData.confirmEmail) {
+        if (!formData.currentPassword) {
+          newErrors.currentPassword = '現在のパスワードを入力してください'
+        }
+        
+        if (formData.newEmail) {
+          if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(formData.newEmail)) {
+            newErrors.newEmail = '有効なメールアドレスを入力してください'
+          }
+          
+          if (formData.newEmail !== formData.confirmEmail) {
+            newErrors.confirmEmail = 'メールアドレスが一致しません'
+          }
+        }
+      }
     return newErrors
   }
+
+  

--- a/front/src/contexts/AuthContext.tsx
+++ b/front/src/contexts/AuthContext.tsx
@@ -4,8 +4,9 @@ import React, { createContext, useContext, useEffect, useState } from 'react'
 import { onAuthStateChanged } from 'firebase/auth'
 import type { User } from 'firebase/auth'
 
-import { AccountRole } from '../types/account' // パスを適切に調整
+import { AccountRole } from '../types/account'
 import { auth } from '../app/firebase/config'
+
 interface UserData {
   user: User | null
   role?: AccountRole
@@ -19,17 +20,49 @@ interface AuthContextType extends UserData {
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080'
 const AuthContext = createContext<AuthContextType | undefined>(undefined)
 
-// こちらのファイルをproviders.tsxファイルでインポートすることで全てのページの認証状態を管理している
-// 各ページの情報を取得し、ログイン状態に応じての処理をProtectRoute.tsxで記述してこちらの関数を各ファイルで
-// インポートしてログイン状態に応じて詳細な対処をしている。
+// メール変更検知と同期のための関数
+const syncEmailWithBackend = async (user: User): Promise<void> => {
+  try {
+    // ローカルストレージから変更予定のメールアドレス情報を取得
+    const pendingEmailChange = localStorage.getItem('pendingEmailChange')
+
+    // 何もなかったらリターン
+    if (!pendingEmailChange) return
+
+    const { firebaseUid, newEmail } = JSON.parse(pendingEmailChange)
+
+    // ユーザーIDが一致し、現在のメールが新しいメール（変更後）と一致する場合
+    if (user.uid === firebaseUid && user.email === newEmail) {
+      // バックエンドAPIを呼び出して更新
+      const response = await fetch(`${API_URL}/auth/users/email`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          firebase_uid: user.uid,
+          new_email: user.email,
+        }),
+      })
+
+      if (!response.ok) {
+        console.error('バックエンドのメールアドレス更新に失敗しました')
+      } else {
+        // 成功したら保存していた情報を削除
+        localStorage.removeItem('pendingEmailChange')
+      }
+    }
+  } catch (error) {
+    console.error('メールアドレス同期エラー:', error)
+  }
+}
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [userData, setUSerData] = useState<UserData>({
+  const [userData, setUserData] = useState<UserData>({
     user: null,
     role: undefined,
     loading: true,
   })
-
   // onAuthStateChangedについて、IDトークンの有効期限は1時間で、リフレッシュトークンの有効期限は二週間
   // ユーザーが1時間以上アプリを使用しなかった場合、アプリを再利用したとき、リフレッシュトークンを使って新しいIDトークンが取得する
   // 1時間使用しなかった場合、リフレッシュトークンを使用してIDトークンを取得できればログアウトはされないが、取得に失敗した場合はログアウトになる
@@ -38,24 +71,29 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, async (user) => {
       if (user) {
-        // ユーザーがログインしている場合はバックエンドからロール情報を取得
+        // ユーザーがログインしている場合
         try {
+          // メールアドレス変更の検知と同期処理
+          await syncEmailWithBackend(user)
+
+          // バックエンドからロール情報を取得
           const userRole = await fetchUserRole(user.uid)
-          setUSerData({ user, role: userRole, loading: false })
+          setUserData({ user, role: userRole, loading: false })
         } catch (error) {
-          console.error('ユーザーロール取得エラー', error)
-          setUSerData({ user, loading: false })
+          console.error('ユーザー情報取得エラー:', error)
+          setUserData({ user, loading: false })
         }
-        // ここが実行される！トークンが期限切れになった場合
       } else {
-        setUSerData({ user: null, loading: false })
+        // ログアウト状態
+        setUserData({ user: null, loading: false })
       }
     })
+
     return () => unsubscribe()
   }, [])
 
   const setUserRole = (role: AccountRole) => {
-    setUSerData((prev) => ({ ...prev, role }))
+    setUserData((prev) => ({ ...prev, role }))
   }
 
   return <AuthContext.Provider value={{ ...userData, setUserRole }}>{children}</AuthContext.Provider>
@@ -72,7 +110,7 @@ const fetchUserRole = async (uid: string): Promise<AccountRole | undefined> => {
     const data = await response.json()
     return data.role
   } catch (error) {
-    console.error('ロール取得エラー', error)
+    console.error('ロール取得エラー:', error)
     return undefined
   }
 }


### PR DESCRIPTION
## 実装前の課題
- ログインした後に、登録しているパスワード、メールアドレスを変更できるようにしたい。

## やったこと

- 選手側のログイン情報を表示機能の実装
- 選手側のログイン編集機能の実装
- 監督側のログイン表示機能の実装
- 監督側のログイン編集機能の実装

## 課題

- ログイン情報で名前などをこちらに入れた方が良かったかもしれないです。
- メールアドレス変更後、再ローディングを行い、新しいメールアドレスでログインした際にメールアドレスの変更が完了となる


## その他（機能の動作）

- パスワード変更機能はメール送信なしで、直接変更することができるように実装を行いました。
- メールアドレス変更は送信されたメールをクリックしてから、firebaseの変更が完了するように実装を行いました。
- メールアドレスについて、送信されたメールをクリックした際にfirebaseでの変更が完了し、新しいメールアドレスでログインすることで、バックエンドでのメールアドレスの変更が完了するように実装を行なっております。


## 動作確認

- 問題なくコンテナが動作し、NextjsとFastApiの画面が表示される
- 問題なくログイン表示機能、ログイン編集機能が正常に起動している。